### PR TITLE
Disable hierarchy pruning

### DIFF
--- a/proto/options.proto
+++ b/proto/options.proto
@@ -310,6 +310,9 @@ message Costing {
     uint32 fixed_speed = 80;
     uint32 axle_count = 81;
     float use_lit = 82;
+    oneof has_disable_hierarchy_pruning {
+      bool disable_hierarchy_pruning = 83;
+    }
   }
 
   oneof has_options {

--- a/scripts/valhalla_build_config
+++ b/scripts/valhalla_build_config
@@ -255,6 +255,7 @@ config = {
         'max_timedep_distance_matrix': 0,
         'max_alternates': 2,
         'max_exclude_polygons_length': 10000,
+        'max_distance_disable_hierarchy_culling': 0,
     },
     'statsd': {
         'host': Optional(str),
@@ -522,6 +523,7 @@ help_text = {
         'max_timedep_distance_matrix': 'Maximum b-line distance between 2 most distant locations in meters to allow a time-dependent matrix',
         'max_alternates': 'Maximum number of alternate routes to allow in a request',
         'max_exclude_polygons_length': 'Maximum total perimeter of all exclude_polygons in meters',
+        'max_distance_disable_hierarchy_culling': 'Maximum search distance allowed with hierarchy culling disabled',
     },
     'statsd': {
         'host': 'The statsd host address',

--- a/src/thor/worker.cc
+++ b/src/thor/worker.cc
@@ -86,6 +86,12 @@ thor_worker_t::thor_worker_t(const boost::property_tree::ptree& config,
       continue;
     }
 
+    // assign max_distance_disable_hierarchy_culling
+    if (kv.first == "max_distance_disable_hierarchy_culling") {
+      max_distance_disable_hierarchy_culling = config.get<float>("service_limits." + kv.first);
+      continue;
+    }
+
     max_matrix_distance.emplace(kv.first, config.get<float>("service_limits." + kv.first +
                                                             ".max_matrix_distance"));
   }

--- a/valhalla/thor/worker.h
+++ b/valhalla/thor/worker.h
@@ -139,6 +139,9 @@ protected:
   baldr::AttributesController controller;
   Centroid centroid_gen;
 
+  // add max_distance_disable_hierarchy_culling
+  float max_distance_disable_hierarchy_culling;
+
 private:
   std::string service_name() const override {
     return "thor";


### PR DESCRIPTION
# Issue
[Disable hierarchy pruning as costing option #3955
](https://github.com/valhalla/valhalla/issues/3955)

## Tasklist
- add a max_distance_disable_hierarchy_culling (long, but exact) to the JSON config generator under service_limits and default to 0
- add a max_distance_disable_hierarchy_culling to thor/worker.h and assign in thor/worker.cc when parsing the config JSON
- add a disable_hierarchy_pruning to the costing options
